### PR TITLE
Better in sync with host time

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -54,6 +54,7 @@
     setTimeout(colorClock, 1000);
   }
 
-  colorClock();
+  // properly match the milliseconds of the host computer
+  setTimeout(colorClock, 1000 - new Date().getMilliseconds());
 
 })();


### PR DESCRIPTION
Before this change, the clock would tick 0-999ms later than the host, depending on when you would load the page.

This change makes sure that the tick happens at the same time as the tick of the host computer.
